### PR TITLE
Use registerTwigExtension()

### DIFF
--- a/src/TwigHelpers.php
+++ b/src/TwigHelpers.php
@@ -29,7 +29,7 @@ class TwigHelpers extends \craft\base\Plugin
 
         self::$plugin = $this;
 
-        Craft::$app->view->twig->addExtension(new LaravelMixTwigExtension());
+        Craft::$app->view->registerTwigExtension(new LaravelMixTwigExtension());
 
         Craft::info('LaravelMix plugin loaded', __METHOD__);
     }


### PR DESCRIPTION
Fixes a bug where the plugin may cause Twig to be loaded before it should be, and another bug where the extension might not be available if the Template Mode ever changes from CP to Site, or vise-versa.